### PR TITLE
feat(Point): 유저 Point 조회 기능 구현 

### DIFF
--- a/src/point/point.controller.spec.ts
+++ b/src/point/point.controller.spec.ts
@@ -2,12 +2,10 @@ import { PointService } from './point.service';
 import { PointController } from './point.controller';
 import { Test, TestingModule } from '@nestjs/testing';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
-// import { UserPointTable } from '../database/userpoint.table';
 
 describe('PointController', () => {
   let pointController: PointController;
   let pointService: DeepMocked<PointService>;
-  // let userPointTable: DeepMocked<UserPointTable>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -17,16 +15,11 @@ describe('PointController', () => {
           provide: PointService,
           useValue: createMock<PointService>(),
         },
-        // {
-        //   provide: UserPointTable,
-        //   useValue: createMock<UserPointTable>(),
-        // },
       ],
     }).compile();
 
     pointController = module.get<PointController>(PointController);
     pointService = module.get(PointService);
-    // userPointTable = module.get(UserPointTable);
   });
 
   describe('point 조회시,', () => {
@@ -36,12 +29,12 @@ describe('PointController', () => {
 
       // 유효하지 않은 ID로 조회할 때, 컨트롤러는 서비스가 던지는 에러를 그대로 반환하는지 테스트합니다.
       it('실패 응답을 반환한다.', async () => {
-        pointService.point.mockRejectedValue(new Error(errorMessage));
+        pointService.getPointById.mockRejectedValue(new Error(errorMessage));
 
         await expect(pointController.point(invalidId)).rejects.toThrowError(
           errorMessage,
         );
-        expect(pointService.point).toHaveBeenCalledWith(invalidId);
+        expect(pointService.getPointById).toHaveBeenCalledWith(invalidId);
       });
     });
 
@@ -51,12 +44,12 @@ describe('PointController', () => {
 
       // 유효한 ID로 조회할 때, 컨트롤러는 서비스가 던지는 응답을 그대로 반환하는지 테스트 합니다.
       it('성공 응답을 반환한다.', async () => {
-        pointService.point.mockResolvedValue(expectedResult);
+        pointService.getPointById.mockResolvedValue(expectedResult);
 
         const result = await pointController.point(validId);
 
         expect(result).toEqual(expectedResult);
-        expect(pointService.point).toHaveBeenCalledWith(validId);
+        expect(pointService.getPointById).toHaveBeenCalledWith(validId);
       });
     });
   });

--- a/src/point/point.controller.ts
+++ b/src/point/point.controller.ts
@@ -17,7 +17,7 @@ export class PointController {
 
   @Get(':id')
   async point(@Param('id', ParseUserIdPipe) id: number): Promise<UserPoint> {
-    return this.pointService.point(id);
+    return this.pointService.getPointById(id);
   }
 
   /**

--- a/src/point/point.service.spec.ts
+++ b/src/point/point.service.spec.ts
@@ -1,18 +1,57 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PointService } from './point.service';
+import { UserPointTable } from '../database/userpoint.table';
+import { UserPoint } from './point.model';
 
 describe('PointService', () => {
-  let service: PointService;
+  let pointService: PointService;
+  let userPointTable: DeepMocked<UserPointTable>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [PointService],
+      controllers: [],
+      providers: [
+        PointService,
+        {
+          provide: UserPointTable,
+          useValue: createMock<UserPointTable>(),
+        },
+      ],
     }).compile();
 
-    service = module.get<PointService>(PointService);
+    pointService = module.get<PointService>(PointService);
+    userPointTable = module.get(UserPointTable);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('getPointById', () => {
+    describe('id가 유효하지않으면', () => {
+      const validId = -3;
+      const errorMessage = 'Database error';
+
+      it('실패한다.', async () => {
+        userPointTable.selectById.mockRejectedValue(new Error(errorMessage));
+        const expectedResult = () => userPointTable.selectById(validId);
+        await expect(expectedResult).rejects.toThrow(errorMessage);
+      });
+    });
+
+    describe('id가 유효하면', () => {
+      const validId: number = 1;
+      const expectedResult: UserPoint = {
+        id: validId,
+        point: 100,
+        updateMillis: Date.now(),
+      };
+
+      it('성공적으로 유저 포인트를 반환한다.', async () => {
+        userPointTable.selectById.mockResolvedValue(expectedResult);
+
+        const result = await pointService.getPointById(validId);
+
+        expect(result).toEqual(expectedResult);
+        expect(userPointTable.selectById).toHaveBeenCalledWith(validId);
+      });
+    });
   });
 });

--- a/src/point/point.service.ts
+++ b/src/point/point.service.ts
@@ -1,15 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { PointHistory, UserPoint } from './point.model';
-import { UserPointTable } from 'src/database/userpoint.table';
-import { PointHistoryTable } from 'src/database/pointhistory.table';
+import { UserPointTable } from '../database/userpoint.table';
 
 @Injectable()
 export class PointService {
-  constructor() {} // private readonly historyDb: PointHistoryTable, // private readonly userDb: UserPointTable,
+  constructor(private readonly userDb: UserPointTable) {} // private readonly historyDb: PointHistoryTable, // private readonly userDb: UserPointTable,
 
-  //TODO - 특정 유저의 포인트를 조회하는 기능을 작성해주세요.
-  async point(id: number): Promise<UserPoint> {
-    return { id: id, point: 0, updateMillis: Date.now() };
+  async getPointById(id: number): Promise<UserPoint> {
+    return await this.userDb.selectById(id);
   }
 
   //TODO - 특정 유저의 포인트 충전/이용 내역을 조회하는 기능을 작성해주세요.


### PR DESCRIPTION
### 작업 내역
- **유저 Point 조회 기능 구현** (서비스 레이어구현)
    - 컨트롤러 단에서 전달하는 id를 기반으로 포인트를 조회합니다.
 - **유저 Point 조회 기능 단위 테스트 구현**
    - 컨트롤러 단에서 전달한 id로 id를 조회하는 selectbId 를 성공적으로 호출하는 가를 확인합니다. 
    
### 의사결정 흐름
- 사용자 ID의 유효성 검사를 Nest.js에서 제공하는 Pipe로 처리하는 것이 적절하다고 판단하여, id를 기반으로 사용자의 포인트를 조회하는 로직만 구현하게 되었습니다.

### 리뷰 포인트
- 모든 경계 케이스를 포함하여 테스트가 충분히 작성되었는지, 혹은 추가적으로 고려할 시나리오가 있는지 확인 부탁드립니다.
